### PR TITLE
Fix optional input being a breaking change

### DIFF
--- a/src/Console/spec/Usage/Model/BooleanOptionValueSpec.php
+++ b/src/Console/spec/Usage/Model/BooleanOptionValueSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\my127\Console\Usage\Model;
+
+use my127\Console\Usage\Model\BooleanOptionValue;
+use PhpSpec\ObjectBehavior;
+
+class BooleanOptionValueSpec extends ObjectBehavior
+{
+    function it_can_get_the_value()
+    {
+        $this->beConstructedThrough('create', [true]);
+        $this->value()->shouldBe(true);
+    }
+
+    function it_can_get_the_value_varied()
+    {
+        $this->beConstructedThrough('create', [false]);
+        $this->value()->shouldBe(false);
+    }
+
+    function it_is_equal_to_same_value()
+    {
+        $comparisonTo = BooleanOptionValue::create(true);
+
+        $this->beConstructedThrough('create', [true]);
+        $this->equals($comparisonTo)->shouldBe(true);
+    }
+
+    function it_is_not_equal_to_different_value()
+    {
+        $comparisonTo = BooleanOptionValue::create(true);
+
+        $this->beConstructedThrough('create', [false]);
+        $this->equals($comparisonTo)->shouldBe(false);
+    }
+}

--- a/src/Console/spec/Usage/Model/StringOptionValueSpec.php
+++ b/src/Console/spec/Usage/Model/StringOptionValueSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\my127\Console\Usage\Model;
+
+use my127\Console\Usage\Model\StringOptionValue;
+use PhpSpec\ObjectBehavior;
+
+class StringOptionValueSpec extends ObjectBehavior
+{
+    function it_can_get_the_value()
+    {
+        $this->beConstructedThrough('create', ['testValue']);
+        $this->value()->shouldBe('testValue');
+    }
+
+    function it_can_get_the_value_varied()
+    {
+        $this->beConstructedThrough('create', ['testValue2']);
+        $this->value()->shouldBe('testValue2');
+    }
+
+    function it_is_equal_to_same_value()
+    {
+        $comparisonTo = StringOptionValue::create('testValue');
+
+        $this->beConstructedThrough('create', ['testValue']);
+        $this->equals($comparisonTo)->shouldBe(true);
+    }
+
+    function it_is_not_equal_to_different_value()
+    {
+        $comparisonTo = StringOptionValue::create('testValue');
+
+        $this->beConstructedThrough('create', ['notTestValue']);
+        $this->equals($comparisonTo)->shouldBe(false);
+    }
+}

--- a/src/Console/src/Usage/Input.php
+++ b/src/Console/src/Usage/Input.php
@@ -56,7 +56,11 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
 
     public function argument($argument)
     {
-        return $this->getArgument($argument);
+        $argument = $this->getArgument($argument);
+        if ($argument instanceof OptionValue) {
+            return $argument->value();
+        }
+        return $argument;
     }
 
     public function getArgument($argument)
@@ -71,7 +75,11 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
 
     public function option($option)
     {
-        return $this->getOption($option);
+        $option = $this->getOption($option);
+        if ($option instanceof OptionValue) {
+            return $option->value();
+        }
+        return $option;
     }
 
     public function getOption($option): OptionValue

--- a/src/Console/src/Usage/Model/BooleanOptionValue.php
+++ b/src/Console/src/Usage/Model/BooleanOptionValue.php
@@ -24,7 +24,7 @@ class BooleanOptionValue implements OptionValue
 
     public function equals(OptionValue $value): bool
     {
-        return $value == $this->value;
+        return $value->value() === $this->value;
     }
 
     public function value(): bool

--- a/src/Console/src/Usage/Model/OptionValue.php
+++ b/src/Console/src/Usage/Model/OptionValue.php
@@ -5,4 +5,5 @@ namespace my127\Console\Usage\Model;
 interface OptionValue
 {
     public function equals(OptionValue $value): bool;
+    public function value();
 }

--- a/src/Console/src/Usage/Model/StringOptionValue.php
+++ b/src/Console/src/Usage/Model/StringOptionValue.php
@@ -21,7 +21,7 @@ class StringOptionValue implements OptionValue
 
     public function equals(OptionValue $value): bool
     {
-        return $value == $this->value;
+        return $value->value() == $this->value;
     }
 
     public function value(): string

--- a/src/Console/tests/Test/Usage/InputTest.php
+++ b/src/Console/tests/Test/Usage/InputTest.php
@@ -40,6 +40,29 @@ class InputTest extends TestCase
         Assert::assertEquals(StringOptionValue::create('actual-value'), $input->getOption('t'));
     }
 
+    public function test_input_representation_with_short_getters()
+    {
+        $input = new Input([
+            new Command('foo-cmd'),
+            new Argument('test-arg', 123),
+            new Option(
+                'bool-option',
+                new OptionDefinition(BooleanOptionValue::create(false), OptionDefinition::TYPE_BOOL, 'b'),
+                true
+            ),
+            new Option(
+                'text-option',
+                new OptionDefinition(StringOptionValue::create('default-value'), OptionDefinition::TYPE_VALUE, 't'),
+                'actual-value'
+            ),
+        ], new OptionDefinitionCollection(), new OptionValueFactory());
+
+        Assert::assertEquals(['foo-cmd'], $input->getCommand());
+        Assert::assertEquals(123, $input->argument('test-arg'));
+        Assert::assertEquals(true, $input->option('b'));
+        Assert::assertEquals('actual-value', $input->option('t'));
+    }
+
     public function test_default_options()
     {
         $optionRepository = new OptionDefinitionCollection();
@@ -65,5 +88,32 @@ class InputTest extends TestCase
         Assert::assertEquals(StringOptionValue::create('default-value'), $input->getOption('t'));
         Assert::assertEquals(BooleanOptionValue::create(true), $input->getOption('b0'));
         Assert::assertEquals(StringOptionValue::create('other-default-value'), $input->getOption('t0'));
+    }
+
+    public function test_default_options_with_short_getters()
+    {
+        $optionRepository = new OptionDefinitionCollection();
+        $optionRepository->add(
+            new OptionDefinition(BooleanOptionValue::create(true), OptionDefinition::TYPE_BOOL, 'b0')
+        );
+        $optionRepository->add(
+            new OptionDefinition(StringOptionValue::create('other-default-value'), OptionDefinition::TYPE_BOOL, 't0')
+        );
+
+        $input = new Input([
+            new Option(
+                'bool-option',
+                new OptionDefinition(BooleanOptionValue::create(false), OptionDefinition::TYPE_BOOL, 'b')
+            ),
+            new Option(
+                'text-option',
+                new OptionDefinition(StringOptionValue::create('default-value'), OptionDefinition::TYPE_VALUE, 't')
+            ),
+        ], $optionRepository, new OptionValueFactory());
+
+        Assert::assertEquals(false, $input->option('b'));
+        Assert::assertEquals('default-value', $input->option('t'));
+        Assert::assertEquals(true, $input->option('b0'));
+        Assert::assertEquals('other-default-value', $input->option('t0'));
     }
 }


### PR DESCRIPTION
As input.argument('...') and input.option('...') are the documented examples for commands, it makes sense to not have to update everywhere to use input.argument('...').value() and input.option('...').value()

Also fixed the equals method to compare values rather than object to value.

TODO:
- [x] Tests