### PR TITLE
Add PHP8+ compatible typehints to iterator classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "symfony/event-dispatcher": "^4.0"
 
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "symfony/event-dispatcher": "^4.0"
+        "symfony/event-dispatcher": "^6.1"
 
     },
     "replace": {

--- a/src/Console/src/Application/Event/BeforeActionEvent.php
+++ b/src/Console/src/Application/Event/BeforeActionEvent.php
@@ -4,13 +4,13 @@ namespace my127\Console\Application\Event;
 
 use my127\Console\Application\Section\Section;
 use my127\Console\Usage\Input;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class BeforeActionEvent extends Event
 {
-    private $input;
-    private $preventAction = false;
-    private $section;
+    private Input $input;
+    private bool $preventAction = false;
+    private Section $section;
 
     public function __construct(Input $input, Section $section)
     {

--- a/src/Console/src/Application/Event/InvalidUsageEvent.php
+++ b/src/Console/src/Application/Event/InvalidUsageEvent.php
@@ -5,11 +5,11 @@ namespace my127\Console\Application\Event;
 use my127\Console\Usage\Model\OptionDefinitionCollection;
 use my127\Console\Usage\Parser\InputSequence;
 use my127\Console\Usage\Parser\InputSequenceFactory;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class InvalidUsageEvent extends Event
 {
-    private $input;
+    private InputSequence $input;
 
     public function __construct($args, OptionDefinitionCollection $options)
     {

--- a/src/Console/src/Application/Executor.php
+++ b/src/Console/src/Application/Executor.php
@@ -170,11 +170,11 @@ class Executor implements SectionVisitor
     private function invalidUsage($argv): InvalidUsageEvent
     {
         $this->dispatcher->dispatch(
-            self::EVENT_INVALID_USAGE,
             $event = new InvalidUsageEvent(
                 $argv,
                 $this->buildOptionCollection($this->root->getOptions())
-            )
+            ),
+            self::EVENT_INVALID_USAGE
         );
 
         return $event;
@@ -183,11 +183,11 @@ class Executor implements SectionVisitor
     private function beforeAction(): BeforeActionEvent
     {
         $this->dispatcher->dispatch(
-            self::EVENT_BEFORE_ACTION,
             $event = new BeforeActionEvent(
                 $this->matchedInput,
                 $this->matchedSection
-            )
+            ),
+            self::EVENT_BEFORE_ACTION
         );
 
         return $event;

--- a/src/Console/src/Usage/Input.php
+++ b/src/Console/src/Usage/Input.php
@@ -95,7 +95,7 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->args[$offset];
     }
@@ -103,7 +103,7 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->args[$offset];
     }
@@ -111,7 +111,7 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->args[$offset] = $value;
     }
@@ -119,7 +119,7 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->args[$offset]);
     }
@@ -127,7 +127,7 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function count()
+    public function count(): int
     {
         return count($this->args);
     }
@@ -135,7 +135,7 @@ class Input implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->args);
     }

--- a/src/Console/src/Usage/Model/OptionDefinitionCollection.php
+++ b/src/Console/src/Usage/Model/OptionDefinitionCollection.php
@@ -29,7 +29,7 @@ class OptionDefinitionCollection implements IteratorAggregate, Countable
         return (isset($this->map[$optionName])) ? $this->map[$optionName] : null;
     }
 
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->options);
     }
@@ -45,7 +45,7 @@ class OptionDefinitionCollection implements IteratorAggregate, Countable
         return $merged;
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->options);
     }

--- a/src/Console/src/Usage/Parser/InputSequence.php
+++ b/src/Console/src/Usage/Parser/InputSequence.php
@@ -53,7 +53,7 @@ class InputSequence implements Countable
         return isset($this->options[$definition->getLabel()]);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->positional) + count($this->options);
     }

--- a/src/FSM/src/Runner/InputSequence.php
+++ b/src/FSM/src/Runner/InputSequence.php
@@ -33,7 +33,7 @@ class InputSequence implements Countable
         return count($this->input);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->input);
     }


### PR DESCRIPTION
Update for PHP 8+ compatibility:
* Add typehints to relevant ArrayIterator and Countable classes
* Update symfony/event-dispatcher to version 6
* Modify use of Event-based classes for changes between version.

Note that this will break backwards-compatibility with previous versions. Since workspace requires `dev-master` we will either need to introduce versioning for this library, or introduce an alternate branch (e.g. develop).